### PR TITLE
fix(terraform destroy): fixed the issue doing terraform destroy when …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-aws-dedicated-host
+# Terraform AWS Dedicated Host Module
 
 Terraform module which creates EC2 dedicated host on AWS. Required for macOS instances (mac1.metal)
 
@@ -7,7 +7,7 @@ Terraform module which creates EC2 dedicated host on AWS. Required for macOS ins
 ```hcl
 module "dedicated-host" {
   source            = "DanielRDias/dedicated-host/aws"
-  version           = "0.2.0"
+  version           = "0.2.1"
   instance_type     = "c5.large"
   availability_zone = "us-east-1a"
 }
@@ -22,7 +22,7 @@ provider "aws" {
 
 module "dedicated-host" {
   source            = "DanielRDias/dedicated-host/aws"
-  version           = "0.2.0"
+  version           = "0.2.1"
   instance_type     = "mac1.metal"
   availability_zone = "us-east-1a"
 }
@@ -65,7 +65,6 @@ output "dedicated-host" {
 
 **Note**: AWS has a limited capacity for dedicated hosts. If terraform times out and fails to create the dedicated host, the cloudformation stack will stay in your account until you do `terraform destroy`.
 Check <https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-stack-stuck-progress/> for more details.
-
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,6 @@ No requirements.
 | Name | Description |
 |------|-------------|
 | cf\_stack\_id | Cloud Formation Stack ID |
-| dedicated\_hosts | Dedicated Host ID |
-
+| dedicated\_host\_id | Dedicated Host ID |
+| dedicated\_hosts | Maps with the dedicated hosts IDs |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/amazon/README.md
+++ b/examples/amazon/README.md
@@ -94,5 +94,5 @@ No input.
 | Name | Description |
 |------|-------------|
 | amazon\_linux\_ami | n/a |
-| dedicated-host | n/a |
+| dedicated\_host\_id | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/amazon/README.md
+++ b/examples/amazon/README.md
@@ -2,6 +2,64 @@
 
 Configuration in this directory creates a dedicated host with a amazon linux instance.
 
+## Example source code
+
+``` hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "dedicated-host" {
+  source            = "DanielRDias/dedicated-host/aws"
+  version           = "0.2.1"
+  instance_type     = "c5.large"
+  availability_zone = "us-east-1a"
+  cf_stack_name     = "amzn2-linux-stack"
+}
+
+resource "aws_instance" "amazon" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "c5.large"
+  host_id       = module.dedicated-host.dedicated_host_id
+  subnet_id     = "subnet-xxx" # Subnet ID in the same AZ as the dedicated host
+
+  tags = {
+    Name = "Terraform Amazon Linux"
+  }
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name = "name"
+
+    values = [
+      "amzn2-ami-hvm*",
+    ]
+  }
+
+  filter {
+    name = "owner-alias"
+
+    values = [
+      "amazon",
+    ]
+  }
+}
+
+output "amazon_linux_ami" {
+  value = data.aws_ami.amazon_linux.id
+}
+
+output "dedicated_host_id" {
+  value = module.dedicated-host.dedicated_host_id
+}
+
+```
+
 ## Usage
 
 To run this example you need to execute:

--- a/examples/amazon/main.tf
+++ b/examples/amazon/main.tf
@@ -12,8 +12,8 @@ module "dedicated-host" {
 resource "aws_instance" "amazon" {
   ami           = data.aws_ami.amazon_linux.id
   instance_type = "c5.large"
-  host_id       = module.dedicated-host.dedicated_hosts["HostID"]
-  subnet_id     = "subnet-058cf69f1cc6662e4" # Subnet ID in the same AZ as the dedicated host
+  host_id       = module.dedicated-host.dedicated_host_id
+  subnet_id     = "subnet-xxx" # Subnet ID in the same AZ as the dedicated host
 
   tags = {
     Name = "Terraform Amazon Linux"
@@ -46,6 +46,6 @@ output "amazon_linux_ami" {
   value = data.aws_ami.amazon_linux.id
 }
 
-output "dedicated-host" {
-  value = module.dedicated-host.dedicated_hosts["HostID"]
+output "dedicated_host_id" {
+  value = module.dedicated-host.dedicated_host_id
 }

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -2,6 +2,27 @@
 
 Configuration in this directory creates a dedicated host with no instances attached.
 
+## Example source code
+
+``` hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "dedicated-host" {
+  source            = "DanielRDias/dedicated-host/aws"
+  version           = "0.2.1"
+  instance_type     = "c5.large"
+  availability_zone = "us-east-1a"
+  cf_stack_name     = "basic-stack"
+}
+
+output "dedicated_host_id" {
+  description = "Dedicated Host ID"
+  value       = module.dedicated-host.dedicated_host_id
+}
+```
+
 ## Usage
 
 To run this example you need to execute:

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -54,5 +54,5 @@ No input.
 
 | Name | Description |
 |------|-------------|
-| dedicated-host | Dedicated Host ID |
+| dedicated\_host\_id | Dedicated Host ID |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -9,7 +9,7 @@ module "dedicated-host" {
   cf_stack_name     = "basic-stack"
 }
 
-output "dedicated-host" {
+output "dedicated_host_id" {
   description = "Dedicated Host ID"
-  value       = module.dedicated-host.dedicated_hosts["HostID"]
+  value       = module.dedicated-host.dedicated_host_id
 }

--- a/examples/macOS/README.md
+++ b/examples/macOS/README.md
@@ -2,6 +2,58 @@
 
 Configuration in this directory creates a dedicated host with a mac1.metal instance.
 
+## Example source code
+
+``` hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "dedicated-host" {
+  source            = "DanielRDias/dedicated-host/aws"
+  version           = "0.2.1"
+  instance_type     = "mac1.metal"
+  availability_zone = "us-east-1a"
+  cf_stack_name     = "mac-stack"
+}
+
+resource "aws_instance" "mac" {
+  ami           = data.aws_ami.mac.id
+  instance_type = "mac1.metal"
+  host_id       = module.dedicated-host.dedicated_host_id
+  subnet_id     = "subnet-xxx" # Subnet ID in the same AZ as the dedicated host
+
+  tags = {
+    Name = "Terraform Mac"
+  }
+}
+
+data "aws_ami" "mac" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["amzn-ec2-macos-10.15*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["amazon"]
+}
+
+output "mac_ami" {
+  value = data.aws_ami.mac.id
+}
+
+output "dedicated_host_id" {
+  value = module.dedicated-host.dedicated_host_id
+}
+
+```
+
 ## Usage
 
 To run this example you need to execute:

--- a/examples/macOS/README.md
+++ b/examples/macOS/README.md
@@ -106,6 +106,6 @@ No input.
 
 | Name | Description |
 |------|-------------|
-| dedicated-host | n/a |
+| dedicated\_host\_id | n/a |
 | mac\_ami | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/macOS/main.tf
+++ b/examples/macOS/main.tf
@@ -12,8 +12,8 @@ module "dedicated-host" {
 resource "aws_instance" "mac" {
   ami           = data.aws_ami.mac.id
   instance_type = "mac1.metal"
-  host_id       = module.dedicated-host.dedicated_hosts["HostID"]
-  subnet_id     = "subnet-xxxx" # Subnet ID in the same AZ as the dedicated host
+  host_id       = module.dedicated-host.dedicated_host_id
+  subnet_id     = "subnet-xxx" # Subnet ID in the same AZ as the dedicated host
 
   tags = {
     Name = "Terraform Mac"
@@ -40,6 +40,6 @@ output "mac_ami" {
   value = data.aws_ami.mac.id
 }
 
-output "dedicated-host" {
-  value = module.dedicated-host.dedicated_hosts["HostID"]
+output "dedicated_host_id" {
+  value = module.dedicated-host.dedicated_host_id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,13 @@
 output "dedicated_hosts" {
-  description = "Dedicated Host ID"
+  description = "Maps with the dedicated hosts IDs"
   value       = aws_cloudformation_stack.dedicated_hosts.outputs
 }
+
+output "dedicated_host_id" {
+  description = "Dedicated Host ID"
+  value       = length(aws_cloudformation_stack.dedicated_hosts.outputs) > 0 ? aws_cloudformation_stack.dedicated_hosts.outputs["HostID"] : ""
+}
+
 output "cf_stack_id" {
   description = "Cloud Formation Stack ID"
   value       = aws_cloudformation_stack.dedicated_hosts.id


### PR DESCRIPTION
# Description

Closes #1

## Issue

If AWS is out of capacity and terraform fails to apply, we wouldn't be able to do terraform destroy without commenting the modules outputs.

```
$ terraform apply

...
module.dedicated-host.aws_cloudformation_stack.dedicated_hosts: Still creating... [30m0s elapsed]

Error: error waiting for CloudFormation Stack creation: timeout while waiting for state to become 'CREATE_COMPLETE, CREATE_FAILED, DELETE_COMPLETE, DELETE_FAILED, ROLLBACK_COMPLETE, ROLLBACK_FAILED' (last state: 'CREATE_IN_PROGRESS', timeout: 30m0s)

$ terraform destroy  

Error: Invalid index

  on main.tf line 44, in output "dedicated-host":
  44:   value = module.dedicated-host.dedicated_hosts["HostID"]
    |----------------
    | module.dedicated-host.dedicated_hosts is empty map of string

The given key does not identify an element in this collection value.
```

# Fix

CloudFormation outputs will be an empty string in case of error.
Added output with the host_id to be used instead of the CloudFormation map output