### PR TITLE
Support CloudFormation stack tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ module "dedicated-host" {
   version           = "0.2.1"
   instance_type     = "c5.large"
   availability_zone = "us-east-1a"
+
+  tags = {
+    Name = "Terraform Mac"
+  }
 }
 ```
 
@@ -25,6 +29,16 @@ module "dedicated-host" {
   version           = "0.2.1"
   instance_type     = "mac1.metal"
   availability_zone = "us-east-1a"
+
+  tags = {
+    Name = "Terraform Mac"
+  }
+}
+
+resource "aws_ec2_tag" "mac" {
+  resource_id = module.dedicated-host.dedicated_hosts["HostID"]
+  key         = "Name"
+  value       = "Terraform Mac"
 }
 
 resource "aws_instance" "mac" {
@@ -94,6 +108,7 @@ No requirements.
 | cf\_stack\_name | Dedicated host CloudFormation stack name. It can include letters (A-Z and a-z), numbers (0-9), and dashes (-). | `string` | `"dedicated-hosts-stack"` | no |
 | host\_recovery | Indicates whether to enable or disable host recovery for the Dedicated Host. Host recovery is disabled by default. | `string` | `"off"` | no |
 | instance\_type | Specifies the instance type to be supported by the Dedicated Hosts. If you specify an instance type, the Dedicated Hosts support instances of the specified instance type only. | `string` | n/a | yes |
+| tags | A list of tags to associate with the CloudFormation stack. Does not propagate to the Dedicated Host. | `map(string)` | n/a | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudformation_stack" "dedicated_hosts" {
   name = var.cf_stack_name
+  tags = var.tags
 
   template_body = <<STACK
 {
@@ -16,7 +17,7 @@ resource "aws_cloudformation_stack" "dedicated_hosts" {
   },
   "Outputs" : {
     "HostID" : {
-      "Description": "Host ID",  
+      "Description": "Host ID",
       "Value" : { "Ref" : "MyDedicatedHost" }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -25,3 +25,9 @@ variable "cf_stack_name" {
   type        = string
   default     = "dedicated-hosts-stack"
 }
+
+variable "tags" {
+  description = "(Optional) A list of tags to associate with the CloudFormation stack. Does not propagate to the Dedicated Host."
+  type        = map(string)
+  default     = null
+}


### PR DESCRIPTION
Hello! 👋 

Thanks for this module—it made getting started with terraform-managed macOS instances a breeze.

I went looking for the ability to name or tag Dedicated Hosts via CloudFormation and was not able to do so using this module alone. 

It looks like Dedicated Hosts can be tagged [via the console or cli](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/how-dedicated-hosts-work.html#dedicated-hosts-tagging), but CloudFormation template tags don't appear to propagate to Dedicated Hosts. I ended up creating a separate `aws_ec2_tag` resource:

```
resource "aws_ec2_tag" "mac" {
  resource_id = module.dedicated-host.dedicated_hosts["HostID"]
  key         = "Name"
  value       = "Terraform Mac"
}
```

I'd like to tag both the CloudFormation template and the Dedicated Host, so this PR adds passthrough of a `tags` variable to the underlying `cloud_formation_stack` resource.