### PR TITLE
feat: 🎸 Replace cloud formation with aws_ec2_host resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Terraform module which creates EC2 dedicated host on AWS. Required for macOS ins
 ```hcl
 module "dedicated-host" {
   source            = "DanielRDias/dedicated-host/aws"
-  version           = "0.2.1"
+  version           = "1.0.0"
   instance_type     = "c5.large"
   availability_zone = "us-east-1a"
 
@@ -77,8 +77,7 @@ output "dedicated-host" {
 }
 ```
 
-**Note**: AWS has a limited capacity for dedicated hosts. If terraform times out and fails to create the dedicated host, the cloudformation stack will stay in your account until you do `terraform destroy`.
-Check <https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-stack-stuck-progress/> for more details.
+**Note**: AWS has a limited capacity for dedicated hosts. Therefore, if terraform fails, check if AWS has availability in another availability zone.
 
 ## Examples
 
@@ -88,7 +87,7 @@ Check <https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-sta
 
 ## Terraform Docs
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
@@ -97,25 +96,34 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ec2_host.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_host) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| auto\_placement | Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID. | `string` | `"on"` | no |
-| availability\_zone | The Availability Zone in which to allocate the Dedicated Host. | `string` | n/a | yes |
-| cf\_stack\_name | Dedicated host CloudFormation stack name. It can include letters (A-Z and a-z), numbers (0-9), and dashes (-). | `string` | `"dedicated-hosts-stack"` | no |
-| host\_recovery | Indicates whether to enable or disable host recovery for the Dedicated Host. Host recovery is disabled by default. | `string` | `"off"` | no |
-| instance\_type | Specifies the instance type to be supported by the Dedicated Hosts. If you specify an instance type, the Dedicated Hosts support instances of the specified instance type only. | `string` | n/a | yes |
-| tags | A list of tags to associate with the CloudFormation stack. Does not propagate to the Dedicated Host. | `map(string)` | n/a | no |
+| <a name="input_auto_placement"></a> [auto\_placement](#input\_auto\_placement) | (Optional) Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID. Valid values: on, off. Default: on. | `string` | `"on"` | no |
+| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | The Availability Zone in which to allocate the Dedicated Host. | `string` | n/a | yes |
+| <a name="input_host_recovery"></a> [host\_recovery](#input\_host\_recovery) | (Optional) Indicates whether to enable or disable host recovery for the Dedicated Host. Host recovery is disabled by default. | `string` | `"off"` | no |
+| <a name="input_instance_family"></a> [instance\_family](#input\_instance\_family) | (Optional) Specifies the instance family to be supported by the Dedicated Hosts. If you specify an instance family, the Dedicated Hosts support multiple instance types within that instance family. Exactly one of instance\_family or instance\_type must be specified. | `string` | `"undefined"` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | (Optional) Specifies the instance type to be supported by the Dedicated Hosts. If you specify an instance type, the Dedicated Hosts support instances of the specified instance type only. Exactly one of instance\_family or instance\_type must be specified. | `string` | `"undefined"` | no |
+| <a name="input_outpost_arn"></a> [outpost\_arn](#input\_outpost\_arn) | (Optional) The Amazon Resource Name (ARN) of the AWS Outpost on which to allocate the Dedicated Host. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A list of tags to associate with the CloudFormation stack. Does not propagate to the Dedicated Host. | `map(string)` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| cf\_stack\_id | Cloud Formation Stack ID |
-| dedicated\_host\_id | Dedicated Host ID |
-| dedicated\_hosts | Maps with the dedicated hosts IDs |
-
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+| <a name="output_dedicated_host_id"></a> [dedicated\_host\_id](#output\_dedicated\_host\_id) | Dedicated Host ID |
+| <a name="output_dedicated_hosts_arn"></a> [dedicated\_hosts\_arn](#output\_dedicated\_hosts\_arn) | The ARN of the Dedicated Host. |
+<!-- END_TF_DOCS -->

--- a/examples/amazon/README.md
+++ b/examples/amazon/README.md
@@ -11,10 +11,9 @@ provider "aws" {
 
 module "dedicated-host" {
   source            = "DanielRDias/dedicated-host/aws"
-  version           = "0.3.1"
+  version           = "1.0.0"
   instance_type     = "c5.large"
   availability_zone = "us-east-1a"
-  cf_stack_name     = "amzn2-linux-stack"
 }
 
 resource "aws_instance" "amazon" {
@@ -22,6 +21,10 @@ resource "aws_instance" "amazon" {
   instance_type = "c5.large"
   host_id       = module.dedicated-host.dedicated_host_id
   subnet_id     = "subnet-xxx" # Subnet ID in the same AZ as the dedicated host
+
+  credit_specification {
+    cpu_credits = "standard"
+  }
 
   tags = {
     Name = "Terraform Amazon Linux"
@@ -74,7 +77,7 @@ Note that this example may create resources which can cost money. Run `terraform
 
 ## Terraform Docs
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
@@ -83,16 +86,29 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.37.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dedicated-host"></a> [dedicated-host](#module\_dedicated-host) | ../../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_instance.amazon](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| amazon\_linux\_ami | n/a |
-| dedicated\_host\_id | n/a |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+| <a name="output_amazon_linux_ami"></a> [amazon\_linux\_ami](#output\_amazon\_linux\_ami) | n/a |
+| <a name="output_dedicated_host_id"></a> [dedicated\_host\_id](#output\_dedicated\_host\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/examples/amazon/main.tf
+++ b/examples/amazon/main.tf
@@ -4,16 +4,19 @@ provider "aws" {
 
 module "dedicated-host" {
   source            = "../../"
-  instance_type     = "c5.large"
-  availability_zone = "us-east-1a"
-  cf_stack_name     = "amzn2-linux-stack"
+  instance_type     = "t3.nano"
+  availability_zone = "us-east-1b"
 }
 
 resource "aws_instance" "amazon" {
   ami           = data.aws_ami.amazon_linux.id
-  instance_type = "c5.large"
+  instance_type = "t3.nano"
   host_id       = module.dedicated-host.dedicated_host_id
   subnet_id     = "subnet-xxx" # Subnet ID in the same AZ as the dedicated host
+
+  credit_specification {
+    cpu_credits = "standard"
+  }
 
   tags = {
     Name = "Terraform Amazon Linux"

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,8 +11,8 @@ provider "aws" {
 
 module "dedicated-host" {
   source            = "DanielRDias/dedicated-host/aws"
-  version           = "0.3.1"
-  instance_type     = "c5.large"
+  version           = "1.0.0"
+  instance_type     = "t3.nano"
   availability_zone = "us-east-1a"
   cf_stack_name     = "basic-stack"
 }
@@ -37,22 +37,32 @@ Note that this example may create resources which can cost money. Run `terraform
 
 ## Terraform Docs
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
 
 ## Providers
 
-No provider.
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dedicated-host"></a> [dedicated-host](#module\_dedicated-host) | ../../ | n/a |
+
+## Resources
+
+No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| dedicated\_host\_id | Dedicated Host ID |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+| <a name="output_dedicated_host_id"></a> [dedicated\_host\_id](#output\_dedicated\_host\_id) | Dedicated Host ID |
+<!-- END_TF_DOCS -->

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "dedicated-host" {
   source            = "../../"
-  instance_type     = "c5.large"
+  instance_type     = "t3.nano"
   availability_zone = "us-east-1a"
   cf_stack_name     = "basic-stack"
 }

--- a/examples/macOS/README.md
+++ b/examples/macOS/README.md
@@ -11,10 +11,9 @@ provider "aws" {
 
 module "dedicated-host" {
   source            = "DanielRDias/dedicated-host/aws"
-  version           = "0.3.1"
+  version           = "1.0.0"
   instance_type     = "mac1.metal"
   availability_zone = "eu-central-1a"
-  cf_stack_name     = "mac-stack"
 }
 
 resource "aws_instance" "mac" {
@@ -87,7 +86,7 @@ data "aws_ami" "mac" {
 
 ## Terraform Docs
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
@@ -96,16 +95,29 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dedicated-host"></a> [dedicated-host](#module\_dedicated-host) | ../../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_instance.mac](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_ami.mac](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| dedicated\_host\_id | n/a |
-| mac\_ami | n/a |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+| <a name="output_dedicated_host_id"></a> [dedicated\_host\_id](#output\_dedicated\_host\_id) | n/a |
+| <a name="output_mac_ami"></a> [mac\_ami](#output\_mac\_ami) | n/a |
+<!-- END_TF_DOCS -->

--- a/examples/macOS/main.tf
+++ b/examples/macOS/main.tf
@@ -6,7 +6,6 @@ module "dedicated-host" {
   source            = "../../"
   instance_type     = "mac1.metal"
   availability_zone = "eu-central-1a"
-  cf_stack_name     = "mac-stack"
 }
 
 resource "aws_instance" "mac" {

--- a/main.tf
+++ b/main.tf
@@ -1,26 +1,13 @@
-resource "aws_cloudformation_stack" "dedicated_hosts" {
-  name = var.cf_stack_name
-  tags = var.tags
-
-  template_body = <<STACK
-{
-  "Resources" : {
-    "MyDedicatedHost": {
-      "Type" : "AWS::EC2::Host",
-      "Properties" : {
-          "AutoPlacement" : "${var.auto_placement}",
-          "AvailabilityZone" : "${var.availability_zone}",
-          "HostRecovery" : "${var.host_recovery}",
-          "InstanceType" : "${var.instance_type}"
-        }
-    }
-  },
-  "Outputs" : {
-    "HostID" : {
-      "Description": "Host ID",
-      "Value" : { "Ref" : "MyDedicatedHost" }
-    }
-  }
+locals {
+  is_family_type = var.instance_family != "undefined" ? true : false
 }
-STACK
+
+resource "aws_ec2_host" "this" {
+  auto_placement    = var.auto_placement
+  availability_zone = var.availability_zone
+  host_recovery     = var.host_recovery
+  instance_family   = local.is_family_type ? var.instance_family : null
+  instance_type     = local.is_family_type ? null : var.instance_type
+  outpost_arn       = var.outpost_arn
+  tags              = var.tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,9 @@
-output "dedicated_hosts" {
-  description = "Maps with the dedicated hosts IDs"
-  value       = aws_cloudformation_stack.dedicated_hosts.outputs
+output "dedicated_hosts_arn" {
+  description = "The ARN of the Dedicated Host."
+  value       = aws_ec2_host.this.arn
 }
 
 output "dedicated_host_id" {
   description = "Dedicated Host ID"
-  value       = length(aws_cloudformation_stack.dedicated_hosts.outputs) > 0 ? aws_cloudformation_stack.dedicated_hosts.outputs["HostID"] : ""
-}
-
-output "cf_stack_id" {
-  description = "Cloud Formation Stack ID"
-  value       = aws_cloudformation_stack.dedicated_hosts.id
+  value       = aws_ec2_host.this.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
-variable "instance_type" {
-  description = "Specifies the instance type to be supported by the Dedicated Hosts. If you specify an instance type, the Dedicated Hosts support instances of the specified instance type only."
+variable "auto_placement" {
+  description = "(Optional) Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID. Valid values: on, off. Default: on."
   type        = string
+  default     = "on"
 }
 
 variable "availability_zone" {
@@ -8,22 +9,28 @@ variable "availability_zone" {
   type        = string
 }
 
-variable "auto_placement" {
-  description = "Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID."
-  type        = string
-  default     = "on"
-}
-
 variable "host_recovery" {
-  description = "Indicates whether to enable or disable host recovery for the Dedicated Host. Host recovery is disabled by default."
+  description = "(Optional) Indicates whether to enable or disable host recovery for the Dedicated Host. Host recovery is disabled by default."
   type        = string
   default     = "off"
 }
 
-variable "cf_stack_name" {
-  description = "Dedicated host CloudFormation stack name. It can include letters (A-Z and a-z), numbers (0-9), and dashes (-)."
+variable "instance_type" {
+  description = "(Optional) Specifies the instance type to be supported by the Dedicated Hosts. If you specify an instance type, the Dedicated Hosts support instances of the specified instance type only. Exactly one of instance_family or instance_type must be specified."
   type        = string
-  default     = "dedicated-hosts-stack"
+  default     = "undefined"
+}
+
+variable "instance_family" {
+  description = "(Optional) Specifies the instance family to be supported by the Dedicated Hosts. If you specify an instance family, the Dedicated Hosts support multiple instance types within that instance family. Exactly one of instance_family or instance_type must be specified."
+  type        = string
+  default     = "undefined"
+}
+
+variable "outpost_arn" {
+  description = "(Optional) The Amazon Resource Name (ARN) of the AWS Outpost on which to allocate the Dedicated Host."
+  type        = string
+  default     = null
 }
 
 variable "tags" {


### PR DESCRIPTION
Uses aws_ec2_host terraform resource to replace the solution created before terraform had a dedicated resource.

BREAKING CHANGE: 🧨 Replace Cloud Formation with aws_ec2_host TF resource